### PR TITLE
Stop auto-passing value attribute down in DateInput

### DIFF
--- a/src/components/form/components/date-input/date-input.jsx
+++ b/src/components/form/components/date-input/date-input.jsx
@@ -49,7 +49,7 @@ export default class DateInput extends Component {
     id: '',
     labelHtmlFor: '',
     autoFocus: false,
-    value: ''
+    value: { day: '', month: '', year: '' }
   };
 
   static sanitizeInput = (type, value) => {
@@ -200,6 +200,7 @@ export default class DateInput extends Component {
       error,
       labelHtmlFor,
       name,
+      value, // Not used, but prevents it falling into ...rest for D/M/Y inputs
       ...rest
     } = this.props;
     const { data, multiErrors } = this.state;


### PR DESCRIPTION
When the DateInput was changed to take `{...rest}` in #6 , this started passing the value attribute down, which ended up overwriting the values in the context.

For example, from `day.jsx`:

```
...
const Day = ({ label, className, error, value, ...rest }) => {
  const { handleInput, day, name, parentError, passBackError } = useContext(
    DateContext
  );
  if (passBackError) {
    passBackError('day', error);
  }
  return (
    <div className="nhsuk-date-input__item">
      <Label htmlFor={`${name}-day`}>{label}</Label>
      <input
        className={classNames(
          'nhsuk-input',
          'nhsuk-date-input__input',
          'nhsuk-input--width-2',
          { 'nhsuk-input--error': error || parentError },
          className
        )}
        id={`${name}-day`}
        name={`${name}-day`}
        aria-label={`${name}-day input`}
        onChange={e => handleInput('day', e.target.value)}
        value={day || value}
        {...rest}
      />
    </div>
  );
};
...
```

Because value is now being passed down directly by the `{...rest}` operator in `date-input.jsx`, it's overwriting the value being taken from the context, leading to behaviour like this:
![image](https://user-images.githubusercontent.com/21102255/60014306-9a458500-9678-11e9-8015-392b120c2ab8.png)

The `[object Object]` in the fields is actually the `{ day: '..', month: '..', year: '....'} object.
